### PR TITLE
Make toJson method aware of Json sub-types

### DIFF
--- a/json/src/main/java/io/airlift/json/JsonCodec.java
+++ b/json/src/main/java/io/airlift/json/JsonCodec.java
@@ -33,6 +33,7 @@ import java.util.function.Supplier;
 
 import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.json.JsonSubType.isJsonSubType;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -153,6 +154,9 @@ public class JsonCodec<T>
             throws IllegalArgumentException
     {
         try {
+            if (isJsonSubType(mapper, instance)) {
+                return mapper.writeValueAsString(instance);
+            }
             return mapper.writerFor(javaType).writeValueAsString(instance);
         }
         catch (IOException e) {
@@ -214,6 +218,9 @@ public class JsonCodec<T>
             throws IllegalArgumentException
     {
         try {
+            if (isJsonSubType(mapper, instance)) {
+                return mapper.writeValueAsBytes(instance);
+            }
             return mapper.writerFor(javaType).writeValueAsBytes(instance);
         }
         catch (IOException e) {

--- a/json/src/test/java/io/airlift/json/subtype/TestJsonSubType.java
+++ b/json/src/test/java/io/airlift/json/subtype/TestJsonSubType.java
@@ -213,14 +213,21 @@ public class TestJsonSubType
     private static void internalTest(ObjectMapper objectMapper)
             throws JsonProcessingException
     {
+        internalTest(objectMapper, false);
+        internalTest(objectMapper, true);
+    }
+
+    private static void internalTest(ObjectMapper objectMapper, boolean writeWithCodec)
+            throws JsonProcessingException
+    {
         JsonCodecFactory codecFactory = new JsonCodecFactory(() -> objectMapper);
         JsonCodec<Employee> jsonCodec = codecFactory.jsonCodec(Employee.class);
 
-        String programmer1Json = objectMapper.writeValueAsString(programmer1);
-        String programmer2Json = objectMapper.writeValueAsString(programmer2);
-        String programmer3Json = objectMapper.writeValueAsString(programmer3);
-        String manager1Json = objectMapper.writeValueAsString(manager1);
-        String manager2Json = objectMapper.writeValueAsString(manager2);
+        String programmer1Json = writeWithCodec ? jsonCodec.toJson(programmer1) : objectMapper.writeValueAsString(programmer1);
+        String programmer2Json = writeWithCodec ? jsonCodec.toJson(programmer2) : objectMapper.writeValueAsString(programmer2);
+        String programmer3Json = writeWithCodec ? jsonCodec.toJson(programmer3) : objectMapper.writeValueAsString(programmer3);
+        String manager1Json = writeWithCodec ? jsonCodec.toJson(manager1) : objectMapper.writeValueAsString(manager1);
+        String manager2Json = writeWithCodec ? jsonCodec.toJson(manager2) : objectMapper.writeValueAsString(manager2);
 
         for (int i = 0; i < 2; ++i) {
             Employee deserializedProgrammer1 = (i == 0) ? objectMapper.readValue(programmer1Json, Employee.class) : jsonCodec.fromJson(programmer1Json);


### PR DESCRIPTION
Don't call `writerFor(javaType)` when the instance being serialized is a Json sub-type. `writerFor(javaType)` subverts the sub-type detection during serialization.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [X] Git commit messages follow https://cbea.ms/git-commit/.
 - [X] All automated tests are passing.
 - [X] Pull request was categorized using one of the existing labels.
